### PR TITLE
Fix signing and sharing facts

### DIFF
--- a/examples/intermediary_request/app.rb
+++ b/examples/intermediary_request/app.rb
@@ -12,18 +12,18 @@ user = ARGV.first
 
 # Even its a silly test lets check if the user's email is equal test@test.org
 # without ever leaking information about the user's fact.
-res = settings.client.request_information(@selfid, [{
+res = @app.request_information(user, [{
   source: Selfid::SOURCE_USER_SPECIFIED,
   fact: Selfid::FACT_EMAIL,
   operator: '==',
   value: 'test@test.org'
-}], proxy: ENV['SELF_INTERMEDIARY'], type: :sync)
+}], intermediary: ENV['SELF_INTERMEDIARY'], type: :sync)
 
 if res.nil? # The request can timeout
   p "Request has timed out"
 elsif res.accepted? # The user accepts the intermediary request
   p "Request has been accepted"
-  p "Your assertion is #{res.facts[Selfid::FACT_EMAIL].result}"
+  p "Your assertion is #{res.fact(Selfid::FACT_EMAIL).result}"
 elsif res.rejected? # The user rejects the intermediary request
   p "Request has been rejected"
 elsif res.unauthorized? # You're not a connection for the specified user

--- a/lib/jwt.rb
+++ b/lib/jwt.rb
@@ -20,12 +20,16 @@ module Selfid
     #
     # @param input [string] input to be prepared
     def prepare(input)
+      signed(input).to_json
+    end
+
+    def signed(input)
       payload = encode(input.to_json)
       {
         payload: payload,
         protected: header,
         signature: sign("#{header}.#{payload}")
-      }.to_json
+      }
     end
 
     def parse(input)

--- a/lib/messages/attestation.rb
+++ b/lib/messages/attestation.rb
@@ -10,14 +10,14 @@ module Selfid
       end
 
       def parse(name, attestation)
-          payload = JSON.parse(@messaging.jwt.decode(attestation[:payload]), symbolize_names: true)
-          @origin = payload[:iss]
-          @source = payload[:source]
-          @verified = valid_signature?(attestation)
+        payload = JSON.parse(@messaging.jwt.decode(attestation[:payload]), symbolize_names: true)
+        @origin = payload[:iss]
+        @source = payload[:source]
+        @verified = valid_signature?(attestation)
 
-          unless payload[name].nil?
-            @value = payload[name]
-          end
+        unless payload[name].nil?
+          @value = payload[name]
+        end
       end
 
       def valid_signature?(jwt)
@@ -29,11 +29,11 @@ module Selfid
       end
 
       def signed
-        @messaging.jwt.encode(@messaging.jwt.prepare(
+        @messaging.jwt.signed(
                               iss: @origin,
                               source: @source,
                               value: @value,
-                            ))
+                            )
       end
     end
   end

--- a/lib/messages/fact.rb
+++ b/lib/messages/fact.rb
@@ -30,6 +30,14 @@ module Selfid
         values.first
       end
 
+      def to_hash
+        {
+          fact: @name,
+          result: @result,
+          operator: @operator,
+          attestations: @attestations,
+        }
+      end
     end
   end
 end

--- a/lib/messages/identity_info_resp.rb
+++ b/lib/messages/identity_info_resp.rb
@@ -40,22 +40,28 @@ module Selfid
       protected
 
       def proto
+        encoded_facts = []
+        @facts.each do |fact|
+          encoded_facts.push(fact.to_hash)
+        end
+        body = @jwt.prepare(
+          typ: MSG_TYPE,
+          iss: @jwt.id,
+          sub: @to,
+          iat: Selfid::Time.now.strftime('%FT%TZ'),
+          exp: (Selfid::Time.now + 3600).strftime('%FT%TZ'),
+          cid: @id,
+          jti: SecureRandom.uuid,
+          status: @status,
+          facts: encoded_facts,
+        )
+
         Msgproto::Message.new(
           type: Msgproto::MsgType::MSG,
           id: SecureRandom.uuid,
           sender: "#{@jwt.id}:#{@messaging.device_id}",
           recipient: "#{@to}:#{@to_device}",
-          ciphertext: @jwt.prepare(
-            typ: MSG_TYPE,
-            iss: @jwt.id,
-            sub: @to,
-            iat: Selfid::Time.now.strftime('%FT%TZ'),
-            exp: (Selfid::Time.now + 3600).strftime('%FT%TZ'),
-            cid: @id,
-            jti: SecureRandom.uuid,
-            status: @status,
-            facts: @facts,
-          ),
+          ciphertext: body,
         )
       end
     end

--- a/lib/ntptime.rb
+++ b/lib/ntptime.rb
@@ -14,6 +14,7 @@ module Selfid
           ntp_time = get_ntp_current_time
           break
         rescue Timeout::Error
+          puts "ntp.google.com timed out, retrying in #{timeout} seconds..."
           sleep timeout
           timeout = timeout+1
         end
@@ -30,7 +31,7 @@ module Selfid
       return ::Time.now.utc if ENV["RAKE_ENV"] == "test"
 
       if @diff.nil?
-        Net::NTP.get("time.google.com")
+        Net::NTP.get("time.google.com", "ntp", 5)
         @@last_check = ::Time.parse(Net::NTP.get.time.to_s).utc
         @diff = (@@last_check - ::Time.now.utc).abs
         @now = (::Time.now + @diff).utc


### PR DESCRIPTION
There was a regression on how the gem was sending back facts/attestations as part of identity_info_resp messages.

The introduced fixes are
- [x] fixed intermediary example by using `intermediary` instead of `proxy` option and `fact attr accessor`
- [x] properly encode facts / attestations when sending an `identity_info_resp`
- [x] reduced ntp library timeout from `60` to `5` seconds as we retry multiple times.