### PR TITLE
cleanup and timeout observers

### DIFF
--- a/lib/messages/authentication_req.rb
+++ b/lib/messages/authentication_req.rb
@@ -8,6 +8,7 @@ module Selfid
   module Messages
     class AuthenticationReq < AuthenticationMessage
       MSG_TYPE = "authentication_req"
+      DEFAULT_EXP_TIMEOUT = 300
 
       def initialize(messaging)
         @typ = MSG_TYPE
@@ -21,6 +22,7 @@ module Selfid
 
         @id = opts[:cid] if opts.include?(:cid)
         @description = opts.include?(:description) ? opts[:description] : nil
+        @exp_timeout = opts.fetch(:exp_timeout, DEFAULT_EXP_TIMEOUT)
       end
 
       def body
@@ -29,7 +31,7 @@ module Selfid
           sub: @to,
           aud: @to,
           iat: Selfid::Time.now.strftime('%FT%TZ'),
-          exp: (Selfid::Time.now + 3600).strftime('%FT%TZ'),
+          exp: (Selfid::Time.now + @exp_timeout).strftime('%FT%TZ'),
           cid: @id,
           jti: SecureRandom.uuid }
       end

--- a/lib/messages/base.rb
+++ b/lib/messages/base.rb
@@ -5,7 +5,7 @@ module Selfid
     class Base
       attr_accessor :from, :from_device, :to, :to_device, :expires, :id,
                     :fields, :typ, :payload, :status, :input, :intermediary,
-                    :description, :sub
+                    :description, :sub, :exp_timeout
 
       def initialize(messaging)
         @client = messaging.client

--- a/lib/services/auth.rb
+++ b/lib/services/auth.rb
@@ -48,7 +48,7 @@ module Selfid
 
         # when a block is given the request will always be asynchronous.
         if block_given?
-          @messaging.set_observer(req, &block)
+          @messaging.set_observer(req, timeout: req.exp_timeout, &block)
           return req.send_message
         end
 

--- a/lib/services/facts.rb
+++ b/lib/services/facts.rb
@@ -49,7 +49,7 @@ module Selfid
 
         # when a block is given the request will always be asynchronous.
         if block_given?
-          @messaging.set_observer(req, &block)
+          @messaging.set_observer(req, timeout: req.exp_timeout, &block)
           return req.send_message
         end
 


### PR DESCRIPTION
UUID based observers were lasting forever if no response was received. 

This pull request introduces a timing out process allowing the consumer to determine the expiration time after what the observer should time out.

When an observer times out it will send back an errored message so the user can check it with `msg.errored?` helper.