### PR TITLE
Allow sending custom messages

### DIFF
--- a/lib/messaging.rb
+++ b/lib/messaging.rb
@@ -75,6 +75,22 @@ module Selfid
       )
     end
 
+    # Send custom mmessage
+    #
+    # @param recipient [string] selfID to be requested
+    # @param type [string] message type
+    # @param request [hash] original message requesing information
+    def send_custom(recipient, request_body)
+        @to_device = @client.devices(recipient).first
+        send_message msg = Msgproto::Message.new(
+          type: Msgproto::MsgType::MSG,
+          id: SecureRandom.uuid,
+          sender: "#{@jwt.id}:#{@device_id}",
+          recipient: "#{recipient}:#{@to_device}",
+          ciphertext: @jwt.prepare(request_body),
+        )
+    end
+
     # Allows incomming messages from the given identity
     #
     # @params payload [string] base64 encoded payload to be sent

--- a/lib/services/messaging.rb
+++ b/lib/services/messaging.rb
@@ -66,6 +66,24 @@ module Selfid
         @client.uuid_observer[cid]
       end
 
+
+      # Send custom mmessage
+      #
+      # @param recipient [string] recipient for the message
+      # @param type [string] message type
+      # @param request [hash] message to be sent
+      def send(recipient, request)
+        request[:jti] = SecureRandom.uuid
+        request[:iss] = @client.jwt.id
+        request[:sub] = recipient
+        request[:iat] = Selfid::Time.now.strftime('%FT%TZ'),
+        request[:exp] = (Selfid::Time.now + 300).strftime('%FT%TZ'),
+        request[:cid] = SecureRandom.uuid unless request.include? :cid
+
+        @client.send_custom(recipient, request)
+      end
+
+
       private
 
       def acl

--- a/lib/services/messaging.rb
+++ b/lib/services/messaging.rb
@@ -83,6 +83,12 @@ module Selfid
         @client.send_custom(recipient, request)
       end
 
+      def notify(recipient, message)
+        send recipient, {
+            typ: 'identities.notify',
+            description: message
+          }
+      end
 
       private
 


### PR DESCRIPTION
This will allow people to send their own message types like

```ruby
@client.send("1112223334", {
          typ: "info_notification_req",
          cid: SecureRandom.uuid,
          description: "<your description here>",
})
```